### PR TITLE
Backtrack when a reserved word is followed by alphaNumChar

### DIFF
--- a/attachment/ParsingWhile.hs
+++ b/attachment/ParsingWhile.hs
@@ -76,7 +76,7 @@ semi :: Parser String
 semi = symbol ";"
 
 rword :: String -> Parser ()
-rword w = lexeme (string w *> notFollowedBy alphaNumChar)
+rword w = (lexeme . try) (string w *> notFollowedBy alphaNumChar)
 
 rws :: [String] -- list of reserved words
 rws = ["if","then","else","while","do","skip","true","false","not","and","or"]

--- a/megaparsec/parsing-simple-imperative-language.md
+++ b/megaparsec/parsing-simple-imperative-language.md
@@ -204,7 +204,7 @@ Let's express it in code:
 
 ```haskell
 rword :: String -> Parser ()
-rword w = lexeme (string w *> notFollowedBy alphaNumChar)
+rword w = (lexeme . try) (string w *> notFollowedBy alphaNumChar)
 
 rws :: [String] -- list of reserved words
 rws = ["if","then","else","while","do","skip","true","false","not","and","or"]


### PR DESCRIPTION
Currently the parser fails on inputs like `if1 := 1` since it doesn’t backtrace when the `notFollowedBy alphaNumChar` parser fails. Afaict this is unintentional.