### PR TITLE
Fix tutorial hints for makeExprParser package

### DIFF
--- a/megaparsec/switch-from-parsec-to-megaparsec.md
+++ b/megaparsec/switch-from-parsec-to-megaparsec.md
@@ -98,7 +98,7 @@ Megaparsec and reasons of their removal:
   `runParser` respectively.
 
 * `chainl`, `chainl1`, `chainr`, and `chainr1`—use
-  [`Text.Megaparsec.Expr`](https://hackage.haskell.org/package/megaparsec/docs/Text-Megaparsec-Expr.html)
+  [`Control.Monad.Combinators.Expr`](https://hackage.haskell.org/package/parser-combinators/docs/Control-Monad-Combinators-Expr.html)
   instead.
 
 ## Completely changed things


### PR DESCRIPTION
Since `makeExprParser` was moved from `Text.Megaparsec.Expr` in the
`megaparsec` package to `Control.Monad.Combinators.Expr` in the
`parser-combinators` package, link here instead.

This fixes mrkkrp/megaparsec#346.