### PR TITLE
Fix some bugs

### DIFF
--- a/megaparsec/megaparsec.md
+++ b/megaparsec/megaparsec.md
@@ -2718,7 +2718,7 @@ like this:
     it "fails on 'b's producing correct error message" $
       parse myParser "" "bbb" `shouldFailWith`
         TrivialError
-          (initialPos "" :| [])
+          0
           (Just (Tokens ('b' :| [])))
           (Set.singleton (Tokens ('a' :| [])))
 ```

--- a/megaparsec/megaparsec.md
+++ b/megaparsec/megaparsec.md
@@ -2988,7 +2988,7 @@ stream.
 [ast]: https://en.wikipedia.org/wiki/Abstract_syntax_tree
 [more-speed-more-power]: https://markkarpov.com/post/megaparsec-more-speed-more-power.html
 [more-speed-more-power-hope]: https://markkarpov.com/post/megaparsec-more-speed-more-power.html#there-is-hope
-[megaparsec-tests]: https://github.com/mrkkrp/megaparsec/tree/master/tests
+[megaparsec-tests]: https://github.com/mrkkrp/megaparsec/tree/master/megaparsec-tests/tests
 [hspec-megaparsec-tests]: https://github.com/mrkkrp/hspec-megaparsec/blob/master/tests/Main.hs
 
 ***

--- a/megaparsec/megaparsec.md
+++ b/megaparsec/megaparsec.md
@@ -1,4 +1,4 @@
----
+cd---
 title: Megaparsec tutorial from IH book
 desc: This is a Megaparsec tutorial which originally was written as a chapter for the Intermediate Haskell book.
 difficulty: 1
@@ -2564,7 +2564,7 @@ instance ShowErrorComponent Custom where
     parseErrorTextPretty (TrivialError @Char @Void undefined us es)
       ++ showPosStack stack
   showErrorComponent (FancyWithLocation stack cs) =
-    showErrorComponent cs
+    parseErrorTextPretty (FancyError @Text @Void undefined (Set.singleton cs))
       ++ showPosStack stack
 
 showPosStack :: [String] -> String


### PR DESCRIPTION
#### 1. Fix instance of ShowErrorComponent


I tried to execute the program in [Catching parse errors in running parser](https://markkarpov.com/megaparsec/megaparsec.html#catching-parse-errors-in-running-parser), then I occurred this error. 

```
/home/yamada/test/190707/parser.hs:37:5: error:
    • No instance for (ShowErrorComponent (ErrorFancy Void))
        arising from a use of ‘showErrorComponent’
    • In the first argument of ‘(++)’, namely ‘showErrorComponent cs’
      In the expression: showErrorComponent cs ++ showPosStack stack
      In an equation for ‘showErrorComponent’:
          showErrorComponent (FancyWithLocation stack cs)
            = showErrorComponent cs ++ showPosStack stack
   |
37 |     showErrorComponent cs
   |     ^^^^^^^^^^^^^^^^^^^^^
```
So, I modified `showErrorComponent cs` to
`parseErrorTextPretty (FancyError @Text @Void undefined (Set.singleton cs))` .

#### 2. Fix example of shouldFailWith

I tried to execute the program in [Testing Megaparsec parsers](https://markkarpov.com/megaparsec/megaparsec.html#testing-megaparsec-parsers), then I occurred this error.

```
/home/yamada/test/190707/test.hs:42:12: error:
    • Couldn't match expected type ‘Int’
                  with actual type ‘NonEmpty SourcePos’
    • In the first argument of ‘TrivialError’, namely
        ‘(initialPos "" :| [])’
      In the second argument of ‘shouldFailWith’, namely
        ‘TrivialError
           (initialPos "" :| [])
           (Just (Tokens ('b' :| [])))
           (Set.singleton (Tokens ('a' :| [])))’
      In the second argument of ‘($)’, namely
        ‘parse myParser "" "bbb"
           `shouldFailWith`
             TrivialError
               (initialPos "" :| [])
               (Just (Tokens ('b' :| [])))
               (Set.singleton (Tokens ('a' :| [])))’
   |
42 |           (initialPos "" :| [])
   |            ^^^^^^^^^^^^^^^^^^^
```

So, I modified `(initialPos "" :| [])` to `0`.

#### 3. Fix broken link.

[old link](https://github.com/mrkkrp/megaparsec/tree/master/tests) is broken, so I changed it to [new link](https://github.com/mrkkrp/megaparsec/tree/master/megaparsec-tests/tests)