### PR TITLE
Incorporate some suggestions from Alberto Capitani

### DIFF
--- a/tutorial/megaparsec.md
+++ b/tutorial/megaparsec.md
@@ -4,7 +4,7 @@ desc: This is a Megaparsec tutorial which originally was written as a chapter fo
 difficulty: 1
 date:
   published: February 23, 2019
-  updated: November 7, 2019
+  updated: December 31, 2019
 ---
 
 *This is the Megaparsec tutorial which originally was written as a chapter
@@ -305,7 +305,7 @@ single :: MonadParsec e s m
 single t = token testToken expected
   where
     testToken x = if x == t then Just x else Nothing
-    expected    = E.singleton (Tokens (t:|[]))
+    expected    = Set.singleton (Tokens (t:|[]))
 ```
 
 The `Tokens` data type constructor has nothing in common with the type
@@ -355,10 +355,10 @@ chunk :: MonadParsec e s m
 chunk = tokens (==)
 
 -- from "Text.Megaparsec.Char" and "Text.Megaparsec.Byte":
-string' :: (MonadParsec e s m, CI.FoldCase (Tokens s))
+string' :: (MonadParsec e s m, Data.CaseInsensitive.FoldCase (Tokens s))
   => Tokens s
   -> m (Tokens s)
-string' = tokens ((==) `on` CI.mk)
+string' = tokens ((==) `on` Data.CaseInsensitive.mk)
 ```
 
 They match fixed chunks of input, `chunk` (which has type-constrained
@@ -835,6 +835,10 @@ Important points here:
 * In (5) and (6) we assemble `Authority` and `Uri` values using the
   `RecordWildCards` language extension.
 
+* `void :: Functor f => f a -> f ()` is used to explicitly discard the
+  result to parsing, without we would get warnings about unused values from
+  GHC.
+
 Play with `pUri` in GHCi and see for yourself that it works:
 
 ```
@@ -886,7 +890,8 @@ expecting end of input
 ```
 
 The parse error could be better! What to do? The easiest way to figure out
-what is going on is to use the built-in `dbg` helper:
+what is going on is to use the built-in `dbg` helper from the
+`Text.Megaparsec.Debug` module:
 
 ```haskell
 dbg :: (Stream s, ShowToken (Token s), ShowErrorComponent e, Show a)
@@ -1959,7 +1964,7 @@ section:
 
 module Main (main) where
 
-import Control.Applicative
+import Control.Applicative hiding (some)
 import Control.Monad (void)
 import Data.Text (Text)
 import Data.Void
@@ -2319,7 +2324,8 @@ data ErrorItem t
   | EndOfInput               -- ^ End of input
 ```
 
-And here is `ErrorFancy`:
+`NonEmpty` is a type for non-empty lists, it comes from
+`Data.List.NonEmpty`. And here is `ErrorFancy`:
 
 ```haskell
 data ErrorFancy e
@@ -2446,7 +2452,7 @@ incorrectIndent :: MonadParsec e s m
   -> Pos               -- ^ Reference indentation level
   -> Pos               -- ^ Actual indentation level
   -> m a
-incorrectIndent ord ref actual = fancyFailure . E.singleton $
+incorrectIndent ord ref actual = fancyFailure . Set.singleton $
   ErrorIndentation ord ref actual
 ```
 
@@ -2549,7 +2555,7 @@ Here is a complete program demonstrating typical usage of `observing`:
 
 module Main (main) where
 
-import Control.Applicative
+import Control.Applicative hiding (some)
 import Data.List (intercalate)
 import Data.Set (Set)
 import Data.Text (Text)
@@ -2832,7 +2838,7 @@ Let us start with an example:
 
 module Main (main) where
 
-import Control.Applicative
+import Control.Applicative hiding (some)
 import Data.Text (Text)
 import Data.Void
 import Test.Hspec


### PR DESCRIPTION
The suggestions were sent in a private email.

For those that I did not include:

```
MPT: -- | @'observing' p@ allows to "observe" failure of the @p@ parser, should
-- > @
```

Sorry, I do not understand what this means.

----

```
--> In "Parse errors":
     - import qualified Data.Text as T (showErrorComponent (NotKeyword txt) = T.unpack txt ++ " is not a keyword")
```

In this case, and in other similar cases there is no import section preceding the examples, so there is no really a place to put this. One solution is to add explicit import sections, but it's hard to decide where to put them because what we often show is just different snippets that are not necessarily parts of the same program or module.

----

```
MPT: "The Tokens data type constructor has nothing in common with the type function Tokens that we have discussed previously. In fact, Tokens is one of constructors of ErrorItem and it is used to specify concrete sequence of tokens we expected to match."
--> I think it would be clearer to use a type synonym like "ExpectedTokens"
```

The naming is just what we have right now. I'm not a big fan of adding extra aliases like this, because in the end you'll just have more names to remember and that's even more confusing.

----

```
MPT: "We can now define NEWLINE from the table above:"
--> When defining a function that is already present in a Megaparsec library, mention the library. (As in other parts of the document.)
```

It was mentioned above that `newline` comes from a module in the library:

> These modules contain two similar sets of helper parsers such as:

----

```
MPT: parseTest (string' "foo" :: Parser Text) "FoZ
    expecting "foo"
--> expecting case insensitive "foo"
```

Would be nice to have, but hard to retrofit now.

----

```
MPT: Control.Applicative.Combinators
    Due to the nature of the Applicative and Alternative abstractions, THEY ARE PRONE TO MEMORY LEAKS (?!) and not as efficient as their monadic counterparts. Although all the combinators we provide in this module are perfectly expressible in terms of Applicative and Alternative, please PREFER CONTROL.MONAD.COMBINATORS INSTEAD when possible.
--> (If I understand correctly) THEY ARE PRONE TO MEMORY LEAKS: this is truly disturbing: it would seem to suggest never to use this library. PREFER CONTROL.MONAD.COMBINATORS INSTEAD: For what reason then to mention  Control.Applicative.Combinators library?
```

Well, AFAIU this comes from the header of the `Control.Applicative.Combinators` module, so it's not surprising we talk about the module itself in its header.

----

```
MPT: "import qualified Text.Megaparsec.Char.Lexer as L"
-- > Usually "L" is the abbreviation for List; perhaps it would be better to use "LX". In this context there are no conflicts or ambiguities, but in other context with a lot of String processing and "past-and-copy" shortcuts, they could arise.
```

This is debatable. I never use `L` for anything list-related, and yet `L` is what we've been using for lexer modules from the beginning.

----

```
MPT: "TrivialError Int (Maybe (ErrorItem (Token s))) (Set (ErrorItem (Token s)))" "In English: a ParseError is either a TrivialError with at most one unexpected item and a (possibly empty) collection of EXPECTED ITEMS or a FancyError."
-- > It is a little misleading (especially for those who start using the library) to call ErrorItem an ExpectedItem.
```

It was hard to come up with a better name. `ErrorItem`s are used for both unexpected and expected components of an error.

----

```
MPT: "NonEmpty (ParseError s e)"
-- > I never used the library Data.List.NonEmpty, so when I saw "NonEmpty" i thougt that was a constructor of MP library. It would have been useful to have had the indication of the library at the first occurrence of NonEmpty.
```

On one hand sure, it sounds like a good thing to do. On the other hand this module is widely used. We cannot turn Megaparsec tutorial into a general tutorial about Haskell, it is already very long. I added a mention of what `NonEmpty` is anyway.

----

```
MPT: " It is the responsibility of the user to keep ParseErrors sorted by their offsets."
-- > I think an example would be appreciated.
```

That has to be demonstrated here?

----

```
MPT: "Unlike the fail-based approach, trivial parse errors are easy to pattern-match on, inspect, and MODIFY."
-- > Although "fancyFailure" is much more complex than "failure", I think an example would be appreciated. To reduce the size of the tutorial, simpler examples could be included as links to other web pages.
```

Which pages?

----

```
MPT: errorBundlePretty - In 99% of cases you will only need this one function.
-- > A simple example would facilitate its immediate use. Error handling in MP is much more complex than that in Parsec.
```

What the example would contain? I think it amounts to passing bundle from the result of a function like `parse` to `errorBundlePretty`, which is not very hard (or seems simple to me at least).

----

```
MPT: In "Catching parse errors in running parser": parseErrorTextPretty (TrivialError @Text @Void undefined us es)
-- > Given that I have never used TypeApplications:
     - what does "undefined" correspond to (perhaps Int?) and why is the first parameter of TrivialError not specified with @Int ?
     - what does @Void have to do with the other parameters?
```

Here we fix the type variables. The type of both expressions that use type applications is `ParseError s e`, so we need to fix `s` (stream type) and `e` (custom error component type). We pass correspondingly `@Text` so `s ~ Text` and `@Void` so `e ~ Void`.

----

```
MPT: observing
-- > Could one not illustrate itwith a much simpler and shorter example? Perhaps it would be appropriate to do two tutorials: one for beginners and another advanced. For a beginner it is difficult and confusing to separate the basic parts from the advanced ones.
```

It is OK to skip parts that you do not understand. Sorry, I'm only willing to maintain a single tutorial these days.

----

Re `choice'`: yes, it is a nice shortcut.