### PR TITLE
Do not include the static directory in the Nix derivation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,9 +34,15 @@ jobs:
           then nix build '.#site'
           else nix build '.#site-preview'
           fi
+          mkdir publish/
           # Netlify does not see a symlink as a directory, so we have to
           # copy the contents.
           cp -R result/ publish/
+          # The images are relatively heavy so we don't want to include them
+          # in the Nix derivation in order to avoid blowing up the Cachix
+          # cache. Therefore, the static/ directory has to be copied
+          # separately.
+          cp -R --parents static/ publish/
       - name: Deploy to Netlify (preview)
         if: github.ref != 'refs/heads/master'
         uses: nwtgck/actions-netlify@v2

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -96,10 +96,7 @@ buildRoute (GenPat outFile') f = do
 ----------------------------------------------------------------------------
 -- Routes
 
-cssR,
-  jsR,
-  imgR,
-  notFoundR,
+notFoundR,
   atomFeedR,
   resumeHtmlR,
   resumePdfR,
@@ -113,9 +110,6 @@ cssR,
   tagsR,
   tutorialR ::
     Route
-cssR = Ins "static/css/*.css" id
-jsR = Ins "static/js/*.js" id
-imgR = Ins "static/img/**/*" id
 notFoundR = Gen "404.html"
 atomFeedR = Gen "feed.atom"
 resumeHtmlR = Ins "resume/resume.md" (\x -> dropDirectory1 x -<.> "html")
@@ -333,9 +327,6 @@ main = shakeArgs shakeOptions $ do
 
   -- Page implementations
 
-  buildRoute cssR copyFile'
-  buildRoute jsR copyFile'
-  buildRoute imgR copyFile'
   buildRoute notFoundR $ \_ output ->
     justFromTemplate (Left "404 Not Found") "404" output
   buildRoute atomFeedR $ \_ output -> do

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
         "^post.*$"
         "^resume$"
         "^resume/resume\.md$"
-        "^static.*$"
         "^templates.*$"
         "^tutorial.*$"
         "^writing.*$"


### PR DESCRIPTION
Including the images in the derivation blows the Cachix cache very quickly since Nix cannot figure that images stay the same. Solution: copy the static/ directory manually after building the main derivation.